### PR TITLE
Add support for connecting to a pool of servers

### DIFF
--- a/txconnpool/pool.py
+++ b/txconnpool/pool.py
@@ -102,8 +102,14 @@ class Pool(object):
         for each protocol.
 
     @ivar _maxClients: A C{int} indicating the maximum number of clients.
-    @ivar _serverAddress: An L{IAddress} provider indicating the server to
-        connect to.  (Only L{IPv4Address} currently supported.)
+    @ivar _serverAddresses: A list of L{IAddress} provider indicating the
+        server to connect to. (Only L{IPv4Address(es)} currently
+        supported.)
+    @ivar _serverOORRecords: A C{dict} storing downtime of the servers in
+        the pool.
+    @ivar _next_server_index: A C{int} storing the index of the next server
+        to try.
+
     @ivar _reactor: The L{IReactorTCP} provider used to initiate new
         connections.
 

--- a/txconnpool/pool.py
+++ b/txconnpool/pool.py
@@ -221,8 +221,10 @@ class Pool(object):
 
         self._factories.append(factory)
 
-        self._reactor.connectTCP(self._nextServerAddress.host,
-                                 self._nextServerAddress.port,
+        next_server_address = self._nextServerAddress
+
+        self._reactor.connectTCP(next_server_address.host,
+                                 next_server_address.port,
                                  factory)
         d = factory.deferred
 

--- a/txconnpool/test/test_basic.py
+++ b/txconnpool/test/test_basic.py
@@ -14,15 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-
 import unittest
 
-from zope.interface import implements
-
-from twisted.internet.interfaces import IConnector, IReactorTCP
+import mock
+from twisted.internet import protocol
 from twisted.internet.address import IPv4Address
 from twisted.internet.defer import Deferred
-from twisted.internet import protocol
+from twisted.internet.interfaces import IConnector, IReactorTCP
+from zope.interface import implements
 
 from txconnpool.pool import PooledClientFactory, Pool
 
@@ -32,17 +31,17 @@ ADDRESS = IPv4Address('TCP', '127.0.0.1', 11211)
 
 class PooledSimpleProtocol(protocol.Protocol):
     factory = None
-    
+
     def connectionMade(self):
         protocol.Protocol.connectionMade(self)
-        
+
         if self.factory.connectionPool is not None:
             self.factory.connectionPool.clientFree(self)
-        
+
         if self.factory.deferred is not None:
             self.factory.deferred.callback(self)
             self.factory.deferred = None
-    
+
     def set(self, key, value):
         if not hasattr(self, '_dct'):
             self._dct = {}
@@ -50,7 +49,7 @@ class PooledSimpleProtocol(protocol.Protocol):
         d = Deferred()
         d.callback('ok')
         return d
-    
+
     def get(self, key):
         d = Deferred()
         d.callback(getattr(self, '_dct', {}).get(key))
@@ -74,12 +73,11 @@ class StubConnectionPool(object):
         status is C{'free'}, C{'busy'} or C{'gone'} and client is the protocol
         instance that made the call.
     """
+
     def __init__(self):
         self.calls = []
         self.shutdown_deferred = None
         self.shutdown_requested = False
-
-
 
     def clientFree(self, client):
         """
@@ -87,13 +85,11 @@ class StubConnectionPool(object):
         """
         self.calls.append(('free', client))
 
-
     def clientBusy(self, client):
         """
         Record a C{'busy'} call for C{client}.
         """
         self.calls.append(('busy', client))
-
 
     def clientGone(self, client):
         """
@@ -101,9 +97,14 @@ class StubConnectionPool(object):
         """
         self.calls.append(('gone', client))
 
+    def clientFailed(self, client, host, port):
+        """
+        Record a C{'failed'} call for C{client}
+        """
+        self.calls.append(('failed', client))
 
 
-class StubConnector(object):
+class StubConnector(mock.Mock):
     """
     A stub L{IConnector} that can be used for testing.
     """
@@ -114,12 +115,10 @@ class StubConnector(object):
         A L{IConnector.connect} implementation that doesn't do anything.
         """
 
-
     def stopConnecting(self):
         """
         A L{IConnector.stopConnecting} that doesn't do anything.
         """
-
 
 
 class StubReactor(object):
@@ -133,21 +132,19 @@ class StubReactor(object):
     def __init__(self):
         self.calls = []
 
-
     def connectTCP(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         return StubConnector()
 
-
     def addSystemEventTrigger(*args, **kwds):
         pass
-
 
 
 class PooledSimpleProtocolTests(unittest.TestCase):
     """
     Tests for the L{PooledSimpleProtocol}
     """
+
     def test_connectionMadeFiresDeferred(self):
         """
         Test that L{PooledSimpleProtocol.connectionMade} fires the factory's
@@ -163,7 +160,6 @@ class PooledSimpleProtocolTests(unittest.TestCase):
         return d
 
 
-
 class SimpleProtocolClientFactoryTests(unittest.TestCase):
     """
     Tests for the L{SimpleProtocolClientFactory}
@@ -175,6 +171,7 @@ class SimpleProtocolClientFactoryTests(unittest.TestCase):
     @ivar pool: The L{StubConnectionPool} attached to C{self.factory} and
         C{self.protocol}.
     """
+
     def setUp(self):
         """
         Create a L{SimpleProtocolClientFactory} instance and and give it a
@@ -193,8 +190,7 @@ class SimpleProtocolClientFactoryTests(unittest.TestCase):
         """
         self.factory.clientConnectionFailed(StubConnector(), None)
         self.assertEquals(self.factory.connectionPool.calls,
-                          [('busy', self.protocol)])
-
+                          [('busy', self.protocol), ('failed', self.protocol)])
 
     def test_clientConnectionLostNotifiesPool(self):
         """
@@ -204,7 +200,6 @@ class SimpleProtocolClientFactoryTests(unittest.TestCase):
         self.factory.clientConnectionLost(StubConnector(), None)
         self.assertEquals(self.factory.connectionPool.calls,
                           [('busy', self.protocol)])
-
 
     def test_buildProtocolRemovesExistingClient(self):
         """
@@ -218,14 +213,12 @@ class SimpleProtocolClientFactoryTests(unittest.TestCase):
         self.assertEquals(self.factory.connectionPool.calls,
                           [('gone', self.protocol)])
 
-
     def tearDown(self):
         """
         Make sure the L{SimpleProtocolClientFactory} isn't trying to reconnect
         anymore.
         """
         self.factory.stopTrying()
-
 
 
 class SimpleProtocolPoolTests(unittest.TestCase):
@@ -235,13 +228,15 @@ class SimpleProtocolPoolTests(unittest.TestCase):
     @ivar reactor: A L{StubReactor} instance.
     @ivar pool: A L{SimpleProtocolPool} for testing.
     """
+
     def setUp(self):
         """
         Create a L{SimpleProtocolPool}.
         """
         unittest.TestCase.setUp(self)
         self.reactor = StubReactor()
-        self.pool = SimpleProtocolPool(ADDRESS, maxClients=5, reactor=self.reactor)
+        self.pool = SimpleProtocolPool(
+            ADDRESS, maxClients=5, reactor=self.reactor)
 
     def test_clientFreeAddsNewClient(self):
         """
@@ -251,7 +246,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.pool.clientFree(p)
 
         self.assertEquals(self.pool._freeClients, set([p]))
-
 
     def test_clientFreeAddsBusyClient(self):
         """
@@ -265,7 +259,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.assertEquals(self.pool._freeClients, set([p]))
         self.assertEquals(self.pool._busyClients, set([]))
 
-
     def test_clientBusyAddsNewClient(self):
         """
         Test that a client not in the free set gets added to the busy set.
@@ -274,7 +267,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.pool.clientBusy(p)
 
         self.assertEquals(self.pool._busyClients, set([p]))
-
 
     def test_clientBusyAddsFreeClient(self):
         """
@@ -287,7 +279,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
 
         self.assertEquals(self.pool._busyClients, set([p]))
         self.assertEquals(self.pool._freeClients, set([]))
-
 
     def test_clientGoneRemovesFreeClient(self):
         """
@@ -302,7 +293,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.pool.clientGone(p)
         self.assertEquals(self.pool._freeClients, set([]))
 
-
     def test_clientGoneRemovesBusyClient(self):
         """
         Test that a client in the busy set gets removed when
@@ -316,7 +306,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.pool.clientGone(p)
         self.assertEquals(self.pool._busyClients, set([]))
 
-
     def test_performRequestCreatesConnection(self):
         """
         Test that L{SimpleProtocolPool.performRequest} on a fresh instance
@@ -325,15 +314,14 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         def _checkResult(result):
             self.assertEquals(result, 'bar')
 
-
         p = PooledSimpleProtocol()
         p.set('foo', 'bar')
 
         d = self.pool.performRequest('get', 'foo')
         d.addCallback(_checkResult)
-        
+
         args, kwargs = self.reactor.calls.pop()
-        
+
         self.assertEquals(args[:2], (ADDRESS.host, ADDRESS.port))
         self.failUnless(isinstance(args[2], SimpleProtocolClientFactory))
         self.assertEquals(kwargs, {})
@@ -341,7 +329,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         args[2].deferred.callback(p)
 
         return d
-
 
     def test_performRequestUsesFreeConnection(self):
         """
@@ -361,7 +348,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         d.addCallback(_checkResult)
 
         return d
-
 
     def test_performRequestMaxBusyQueuesRequest(self):
         """
@@ -390,7 +376,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
 
         return d
 
-
     def test_performRequestCreatesConnectionsUntilMaxBusy(self):
         """
         Test that L{PooledSimpleProtocol.performRequest} will create new
@@ -410,9 +395,9 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.pool.clientBusy(p)
 
         d = self.pool.performRequest('get', 'foo')
-        
+
         args, kwargs = self.reactor.calls.pop()
-        
+
         self.assertEquals(args[:2], (ADDRESS.host, ADDRESS.port))
         self.failUnless(isinstance(args[2], SimpleProtocolClientFactory))
         self.assertEquals(kwargs, {})
@@ -420,7 +405,6 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         args[2].deferred.callback(p1)
 
         return d
-
 
     def test_pendingConnectionsCountAgainstMaxClients(self):
         """
@@ -431,9 +415,9 @@ class SimpleProtocolPoolTests(unittest.TestCase):
         self.pool.suggestMaxClients(1)
 
         d = self.pool.performRequest('get', 'foo')
-        
+
         args, kwargs = self.reactor.calls.pop()
-        
+
         self.assertEquals(args[:2], (ADDRESS.host, ADDRESS.port))
         self.failUnless(isinstance(args[2], SimpleProtocolClientFactory))
         self.assertEquals(kwargs, {})

--- a/txconnpool/test/test_basic.py
+++ b/txconnpool/test/test_basic.py
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
+import time
 import unittest
 
+import hiro
 import mock
 from twisted.internet import protocol
 from twisted.internet.address import IPv4Address
@@ -23,7 +25,7 @@ from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IConnector, IReactorTCP
 from zope.interface import implements
 
-from txconnpool.pool import PooledClientFactory, Pool
+from txconnpool.pool import PooledClientFactory, Pool, reprForIPv4Address
 
 
 ADDRESS = IPv4Address('TCP', '127.0.0.1', 11211)
@@ -97,7 +99,7 @@ class StubConnectionPool(object):
         """
         self.calls.append(('gone', client))
 
-    def clientFailed(self, client, host, port):
+    def clientFailed(self, client, connector):
         """
         Record a C{'failed'} call for C{client}
         """


### PR DESCRIPTION
on `connectionFailed`, tell the pool to try with the next server address. The old messages will get retried on the previous server address till they eventually fail. ¯_(ツ)_/¯ 

TODO 
- [x] Add tests
- [x] Add requirements file
- [x] Travis?

@zopim/basketcases 
