### PR TITLE
PIKA-277: Enable codecov for this repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
     - pip install -r requirements/test.txt
 script:
     - nosetests --with-cov --cov-report xml .
-    - bash <(curl https://codecov.io/bash)
+    - bash <(curl -S https://raw.githubusercontent.com/zendesk/codecov-bash/master/codecov)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ cache:
 install:
     - pip install -r requirements/test.txt
 script:
-    - nosetests --with-cov .
+    - nosetests --with-cov --cov-report xml .
+    - bash <(curl https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://codecov.io/gh/zendesk/txconnpool/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/zendesk/txconnpool
+
 txconnpool
 ==========
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch: off
+comment:
+  after_n_builds: 4  # Wait until we receive the reports from all tests


### PR DESCRIPTION
### Context

We're turning on codecov for this repo

### Approach

1. Set CODECOV_TOKEN secret in travis
2. Turn on xml coverage report
3. Run codecov-bash snippet

### References

JIRA: https://zendesk.atlassian.net/browse/PIKA-277

@zendesk/pikachu 

### Risks

[None] CI-only change