### PR TITLE
[PIKA-335] Introducing Github CODEOWNERS and update docs related

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner will be requested for
+# review when someone opens a pull request.
+*       @zendesk/pikachu
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+### Context
+
+Describe why this PR exists, what problem you are addressing.
+
+Remember: PRs may be looked at by people outside your team because we have a shared codebase. Make 
+it easy for them to understand and contribute.
+
+
+### Approach
+
+Describe what the changeset is doing. Explain any unconventional approach used in the implementation.
+
+You may also use nice checklists if you're making a PR that is ongoing with a leftover TODO list:
+- [ ] Do this
+- [ ] And that
+- [ ] But also that!
+- [ ] Write tests
+
+If there's any caveat to the work, known accepted issues or risk, list them here too.
+
+
+### Dependencies and References
+
+Put here anything we can look at for reference:
+* jira ticket
+* zendesk tickets
+* dependent PRs
+* related PRs
+* direct link to code that's important to know/understand to make sense of the PR
+
+
+Mention your team, and subject matter experts (if any)
+
+
+### Risks
+
+:warning: DO NOT WRITE **None** :warning:
+
+[Low/Medium/High] Short description why
+
+This section is for the Samson deployers. It may not be you, or anyone from your team!
+Let deployers know what this PR is touching; e.g. "Increase number of request to scribe"


### PR DESCRIPTION
### Context

Slack discussion:
https://zendesk.slack.com/archives/GLLGV7B41/p1587000720098700?thread_ts=1586938255.089800&cid=GLLGV7B41

Introduce the use of Github CODEOWNERS instead of the team mention in the PR description

Similar PR: https://github.com/zendesk/zopim-scribe/pull/1908

### Approach
- [x] Add `.github/CODEOWNERS`
- [x] Deprecate team mention in docs related

### Dependencies and References

https://zendesk.atlassian.net/browse/PIKA-335

@zendesk/pikachu 

### Risks

Low. Only docs change.