### PR TITLE
[DEPENDABOT TRIAL] Add malicious package scanning to your repo

### DIFF
--- a/.github/workflows/scan-malicious-packages.yml
+++ b/.github/workflows/scan-malicious-packages.yml
@@ -1,0 +1,7 @@
+name: Malware Detection PR Scanner
+
+on: [pull_request]
+
+jobs:
+  scan-on-pr:
+    uses: zendesk/prodsec-actions/.github/workflows/malware-detection-pr-scanning.yaml@main


### PR DESCRIPTION
This PR was programatically created as part of Product Security's dependabot trial and snyk replacement efforts
It adds a workflow to your repository which can be used to scan it for malicious packages.
All you have to do is merge this PR.

After you merge this PR you can expect to see a new "check" in all new PRs you make against this repo's branches.
This check will fail if a malicious package is detected

If you have questions reach out to the Product Security team on slack through [#dependabot-trial](https://zendesk.slack.com/archives/C08B577N2SC)